### PR TITLE
fix: make copyright year dynamic, remove unused Footer

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -68,7 +68,7 @@ const Contact = () => {
 
         {/* Footer */}
         <div className="text-center mt-10 pt-8 border-t border-[#E9E9E7]">
-          <p className="text-sm text-[#9B9A97] font-japanese">© 2025 Koji · こうじ</p>
+          <p className="text-sm text-[#9B9A97] font-japanese">© {new Date().getFullYear()} Koji · こうじ</p>
         </div>
       </div>
     </section>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,0 @@
-export const Footer = () => (
-  <div className="text-center mt-12 pt-8 border-t border-border/30">
-    <p className="text-sm text-muted-foreground">Made with ❤️ and lots of ☕</p>
-    <p className="text-xs text-muted-foreground mt-2 font-japanese">© 2024 Koji • こうじ</p>
-  </div>
-);


### PR DESCRIPTION
## Changes

- **Contact.tsx**: Replace hardcoded `© 2025` with `© {new Date().getFullYear()}` so the year is always current
- **Footer.tsx**: Removed — this component was dead code (never imported anywhere). Contact has its own inline footer already
- **Normalized interpunct**: Footer.tsx used `•` (bullet) while Contact.tsx used `·` (middle dot) — unified to `·`

Closes #63