### PR TITLE
fix: use actual favicon.png instead of empty data URI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
- <link rel="apple-touch-icon" href="/favicon.png" />
+    <link rel="apple-touch-icon" href="/favicon.png" />
     <title>Koji - Portfolio</title>
     <meta
       name="description"

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="data:," />
+    <link rel="icon" type="image/png" href="/favicon.png" />
+ <link rel="apple-touch-icon" href="/favicon.png" />
     <title>Koji - Portfolio</title>
     <meta
       name="description"


### PR DESCRIPTION
## Changes

- Replace `data:,` empty data URI with `/favicon.png` (file already exists in `public/`)
- Add `apple-touch-icon` link for iOS home screen and PWA install prompts

Before: browser tabs show no favicon, bookmarks have no icon
After: uses the existing `public/favicon.png` for both favicon and apple touch icon

Closes #61