### PR TITLE
fix: use Notion design system on 404 page, client-side nav

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,24 +1,27 @@
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 const NotFound = () => {
-  const location = useLocation();
+ const location = useLocation();
 
-  useEffect(() => {
-    console.error('404 Error: User attempted to access non-existent route:', location.pathname);
-  }, [location.pathname]);
+ useEffect(() => {
+ console.error('404 Error: User attempted to access non-existent route:', location.pathname);
+ }, [location.pathname]);
 
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
-      </div>
-    </div>
-  );
+ return (
+ <div className="min-h-screen flex items-center justify-center bg-notion-surface">
+ <div className="text-center max-w-md mx-auto px-4">
+ <h1 className="text-6xl font-bold text-notion-ink mb-4">404</h1>
+ <p className="text-xl text-notion-slate mb-8">Oops! Page not found</p>
+ <Link
+ to="/"
+ className="text-notion-purple hover:text-notion-purple-pressed underline transition-colors"
+ >
+ Return to Home
+ </Link>
+ </div>
+ </div>
+ );
 };
 
 export default NotFound;


### PR DESCRIPTION
## Changes

**Design system alignment** — replaces generic Tailwind classes with the site's Notion design tokens from `tailwind.config.ts`:

| Before | After |
|--------|-------|
| `bg-gray-100` | `bg-notion-surface` (`#F7F6F3`) |
| `text-gray-600` | `text-notion-slate` (`#787774`) |
| `text-blue-500 hover:text-blue-700` | `text-notion-purple hover:text-notion-purple-pressed` (`#7766E4` → `#6655D8`) |
| unstyled heading | `text-notion-ink` (`#37352F`) |

**Client-side navigation** — `<a href="/">` → `<Link to="/">` from react-router-dom, avoiding full page reload.

**Minor polish** — larger heading (`text-6xl`), `max-w-md mx-auto` for better readability.

Closes #68