### PR TITLE
Fix accessibility: add skip-to-content link and replace nav buttons with anchor links

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -12,12 +12,17 @@ const Navigation = () => {
  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
  const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>, sectionId: string) => {
- e.preventDefault();
- const element = document.getElementById(sectionId);
- if (element) {
- element.scrollIntoView({ behavior: 'smooth' });
- }
- setIsMenuOpen(false);
+  if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) {
+   return;
+  }
+
+  e.preventDefault();
+  const element = document.getElementById(sectionId);
+  if (element) {
+   window.history.pushState(null, '', `#${sectionId}`);
+   element.scrollIntoView({ behavior: 'smooth' });
+  }
+  setIsMenuOpen(false);
  };
 
  return (

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,158 +1,167 @@
 import { Button } from '@/components/ui/button';
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
+ DropdownMenu,
+ DropdownMenuContent,
+ DropdownMenuItem,
+ DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Menu, X } from 'lucide-react';
 import React, { useState } from 'react';
 
 const Navigation = () => {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+ const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  const scrollToSection = (sectionId: string) => {
-    const element = document.getElementById(sectionId);
-    if (element) {
-      element.scrollIntoView({ behavior: 'smooth' });
-    }
-    setIsMenuOpen(false);
-  };
+ const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>, sectionId: string) => {
+ e.preventDefault();
+ const element = document.getElementById(sectionId);
+ if (element) {
+ element.scrollIntoView({ behavior: 'smooth' });
+ }
+ setIsMenuOpen(false);
+ };
 
-  return (
-    <nav className="fixed top-0 left-0 right-0 z-50 bg-white border-b border-[#E9E9E7]">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between h-16">
-          {/* Logo */}
-          <button
-            type="button"
-            onClick={() => scrollToSection('home')}
-            className="text-lg font-semibold text-[#37352F] font-japanese tracking-tight"
-          >
-            Koji · こうじ
-          </button>
+ return (
+ <nav className="fixed top-0 left-0 right-0 z-50 bg-white border-b border-[#E9E9E7]">
+ <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+ <div className="flex items-center justify-between h-16">
+ {/* Logo */}
+ <a
+ href="#home"
+ onClick={(e) => handleNavClick(e, 'home')}
+ className="text-lg font-semibold text-[#37352F] font-japanese tracking-tight"
+ >
+ Koji · こうじ
+ </a>
 
-          {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center space-x-6">
-            <button
-              type="button"
-              onClick={() => scrollToSection('home')}
-              className="text-sm text-[#787774] hover:text-[#37352F] transition-colors"
-            >
-              Home
-            </button>
-            <button
-              type="button"
-              onClick={() => scrollToSection('about')}
-              className="text-sm text-[#787774] hover:text-[#37352F] transition-colors"
-            >
-              About
-            </button>
+ {/* Desktop Navigation */}
+ <div className="hidden md:flex items-center space-x-6">
+ <a
+ href="#home"
+ onClick={(e) => handleNavClick(e, 'home')}
+ className="text-sm text-[#787774] hover:text-[#37352F] transition-colors"
+ >
+ Home
+ </a>
+ <a
+ href="#about"
+ onClick={(e) => handleNavClick(e, 'about')}
+ className="text-sm text-[#787774] hover:text-[#37352F] transition-colors"
+ >
+ About
+ </a>
 
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  className="text-sm text-[#787774] hover:text-[#37352F] transition-colors"
-                >
-                  Projects
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent className="bg-white border border-[#E9E9E7] shadow-notion-card rounded-[8px]">
-                <DropdownMenuItem
-                  onClick={() => scrollToSection('work')}
-                  className="cursor-pointer text-sm text-[#37352F] hover:bg-[#F7F6F3]"
-                >
-                  Work
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={() => scrollToSection('personal')}
-                  className="cursor-pointer text-sm text-[#37352F] hover:bg-[#F7F6F3]"
-                >
-                  Personal Projects
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+ <DropdownMenu>
+ <DropdownMenuTrigger asChild>
+ <button
+ type="button"
+ className="text-sm text-[#787774] hover:text-[#37352F] transition-colors"
+ >
+ Projects
+ </button>
+ </DropdownMenuTrigger>
+ <DropdownMenuContent className="bg-white border border-[#E9E9E7] shadow-notion-card rounded-[8px]">
+ <DropdownMenuItem
+ onClick={() => {
+ const el = document.getElementById('work');
+ if (el) el.scrollIntoView({ behavior: 'smooth' });
+ setIsMenuOpen(false);
+ }}
+ className="cursor-pointer text-sm text-[#37352F] hover:bg-[#F7F6F3]"
+ >
+ Work
+ </DropdownMenuItem>
+ <DropdownMenuItem
+ onClick={() => {
+ const el = document.getElementById('personal');
+ if (el) el.scrollIntoView({ behavior: 'smooth' });
+ setIsMenuOpen(false);
+ }}
+ className="cursor-pointer text-sm text-[#37352F] hover:bg-[#F7F6F3]"
+ >
+ Personal Projects
+ </DropdownMenuItem>
+ </DropdownMenuContent>
+ </DropdownMenu>
 
-            <a
-              href="https://baxin.pages.dev/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm text-[#787774] hover:text-[#37352F] transition-colors"
-            >
-              Blog
-            </a>
+ <a
+ href="https://baxin.pages.dev/"
+ target="_blank"
+ rel="noopener noreferrer"
+ className="text-sm text-[#787774] hover:text-[#37352F] transition-colors"
+ >
+ Blog
+ </a>
 
-            <button
-              type="button"
-              onClick={() => scrollToSection('contact')}
-              className="bg-[#7766E4] text-white rounded-[8px] px-[18px] py-[9px] text-sm font-medium hover:bg-[#6655D8] transition-colors"
-            >
-              Get In Touch
-            </button>
-          </div>
+ <a
+ href="#contact"
+ onClick={(e) => handleNavClick(e, 'contact')}
+ className="bg-[#7766E4] text-white rounded-[8px] px-[18px] py-[9px] text-sm font-medium hover:bg-[#6655D8] transition-colors"
+ >
+ Get In Touch
+ </a>
+ </div>
 
-          {/* Mobile Menu Button */}
-          <div className="md:hidden">
-            <Button variant="ghost" size="sm" onClick={() => setIsMenuOpen(!isMenuOpen)}>
-              {isMenuOpen ? <X size={20} /> : <Menu size={20} />}
-            </Button>
-          </div>
-        </div>
+ {/* Mobile Menu Button */}
+ <div className="md:hidden">
+ <Button variant="ghost" size="sm" onClick={() => setIsMenuOpen(!isMenuOpen)}>
+ {isMenuOpen ? <X size={20} /> : <Menu size={20} />}
+ </Button>
+ </div>
+ </div>
 
-        {/* Mobile Navigation */}
-        {isMenuOpen && (
-          <div className="md:hidden border-t border-[#E9E9E7]">
-            <div className="py-3 space-y-1">
-              <button
-                type="button"
-                onClick={() => scrollToSection('home')}
-                className="block px-4 py-2.5 text-sm text-[#787774] hover:text-[#37352F] hover:bg-[#F7F6F3] w-full text-left rounded-[8px]"
-              >
-                Home
-              </button>
-              <button
-                type="button"
-                onClick={() => scrollToSection('about')}
-                className="block px-4 py-2.5 text-sm text-[#787774] hover:text-[#37352F] hover:bg-[#F7F6F3] w-full text-left rounded-[8px]"
-              >
-                About
-              </button>
-              <button
-                type="button"
-                onClick={() => scrollToSection('work')}
-                className="block px-4 py-2.5 text-sm text-[#787774] hover:text-[#37352F] hover:bg-[#F7F6F3] w-full text-left rounded-[8px]"
-              >
-                Work
-              </button>
-              <button
-                type="button"
-                onClick={() => scrollToSection('personal')}
-                className="block px-4 py-2.5 text-sm text-[#787774] hover:text-[#37352F] hover:bg-[#F7F6F3] w-full text-left rounded-[8px]"
-              >
-                Personal Projects
-              </button>
-              <a
-                href="https://baxin.pages.dev/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block px-4 py-2.5 text-sm text-[#787774] hover:text-[#37352F] hover:bg-[#F7F6F3] rounded-[8px]"
-              >
-                Blog
-              </a>
-              <button
-                type="button"
-                onClick={() => scrollToSection('contact')}
-                className="block px-4 py-2.5 text-sm text-[#787774] hover:text-[#37352F] hover:bg-[#F7F6F3] w-full text-left rounded-[8px]"
-              >
-                Contact
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
-    </nav>
-  );
+ {/* Mobile Navigation */}
+ {isMenuOpen && (
+ <div className="md:hidden border-t border-[#E9E9E7]">
+ <div className="py-3 space-y-1">
+ <a
+ href="#home"
+ onClick={(e) => handleNavClick(e, 'home')}
+ className="block px-4 py-2.5 text-sm text-[#787774] hover:text-[#37352F] hover:bg-[#F7F6F3] rounded-[8px]"
+ >
+ Home
+ </a>
+ <a
+ href="#about"
+ onClick={(e) => handleNavClick(e, 'about')}
+ className="block px-4 py-2.5 text-sm text-[#787774] hover:text-[#37352F] hover:bg-[#F7F6F3] rounded-[8px]"
+ >
+ About
+ </a>
+ <a
+ href="#work"
+ onClick={(e) => handleNavClick(e, 'work')}
+ className="block px-4 py-2.5 text-sm text-[#787774] hover:text-[#37352F] hover:bg-[#F7F6F3] rounded-[8px]"
+ >
+ Work
+ </a>
+ <a
+ href="#personal"
+ onClick={(e) => handleNavClick(e, 'personal')}
+ className="block px-4 py-2.5 text-sm text-[#787774] hover:text-[#37352F] hover:bg-[#F7F6F3] rounded-[8px]"
+ >
+ Personal Projects
+ </a>
+ <a
+ href="https://baxin.pages.dev/"
+ target="_blank"
+ rel="noopener noreferrer"
+ className="block px-4 py-2.5 text-sm text-[#787774] hover:text-[#37352F] hover:bg-[#F7F6F3] rounded-[8px]"
+ >
+ Blog
+ </a>
+ <a
+ href="#contact"
+ onClick={(e) => handleNavClick(e, 'contact')}
+ className="block px-4 py-2.5 text-sm text-[#787774] hover:text-[#37352F] hover:bg-[#F7F6F3] rounded-[8px]"
+ >
+ Contact
+ </a>
+ </div>
+ </div>
+ )}
+ </div>
+ </nav>
+ );
 };
 
 export default Navigation;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -73,16 +73,14 @@ const Navigation = () => {
             Work
           </a>
         </DropdownMenuItem>
- <DropdownMenuItem
- onClick={() => {
- const el = document.getElementById('personal');
- if (el) el.scrollIntoView({ behavior: 'smooth' });
- setIsMenuOpen(false);
- }}
- className="cursor-pointer text-sm text-[#37352F] hover:bg-[#F7F6F3]"
- >
- Personal Projects
- </DropdownMenuItem>
+        <DropdownMenuItem
+          asChild
+          className="cursor-pointer text-sm text-[#37352F] hover:bg-[#F7F6F3]"
+        >
+          <a href="#personal" onClick={(e) => handleNavClick(e, 'personal')}>
+            Personal Projects
+          </a>
+        </DropdownMenuItem>
  </DropdownMenuContent>
  </DropdownMenu>
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -65,16 +65,14 @@ const Navigation = () => {
  </button>
  </DropdownMenuTrigger>
  <DropdownMenuContent className="bg-white border border-[#E9E9E7] shadow-notion-card rounded-[8px]">
- <DropdownMenuItem
- onClick={() => {
- const el = document.getElementById('work');
- if (el) el.scrollIntoView({ behavior: 'smooth' });
- setIsMenuOpen(false);
- }}
- className="cursor-pointer text-sm text-[#37352F] hover:bg-[#F7F6F3]"
- >
- Work
- </DropdownMenuItem>
+        <DropdownMenuItem
+          asChild
+          className="cursor-pointer text-sm text-[#37352F] hover:bg-[#F7F6F3]"
+        >
+          <a href="#work" onClick={(e) => handleNavClick(e, 'work')}>
+            Work
+          </a>
+        </DropdownMenuItem>
  <DropdownMenuItem
  onClick={() => {
  const el = document.getElementById('personal');

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,10 +17,13 @@ export const Index = () => {
   }, []);
 
   return (
-    <div className="min-h-screen bg-notion-canvas text-notion-ink">
-      <Navigation />
+  <div className="min-h-screen bg-notion-canvas text-notion-ink">
+  <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:rounded focus:shadow-lg focus:text-[#37352F]">
+  Skip to content
+  </a>
+  <Navigation />
 
-      <main>
+  <main id="main-content">
         <Hero />
         <About />
         <WorkProjects />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,9 +18,13 @@ export const Index = () => {
 
   return (
   <div className="min-h-screen bg-notion-canvas text-notion-ink">
-  <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:rounded focus:shadow-lg focus:text-[#37352F]">
-  Skip to content
-  </a>
+    <a
+      href="#main-content"
+      onClick={() => document.getElementById('main-content')?.focus()}
+      className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:rounded focus:shadow-lg focus:text-[#37352F]"
+    >
+      Skip to content
+    </a>
   <Navigation />
 
   <main id="main-content" tabIndex={-1}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,7 +23,7 @@ export const Index = () => {
   </a>
   <Navigation />
 
-  <main id="main-content">
+  <main id="main-content" tabIndex={-1}>
         <Hero />
         <About />
         <WorkProjects />


### PR DESCRIPTION
## Summary

Fixes two accessibility issues in navigation (Closes #65):

### 1. Add skip-to-content link (WCAG 2.1 Level A, 2.4.1 Bypass Blocks)
- Added `id="main-content"` to the `<main>` element in `index.tsx`
- Added a visually-hidden skip-to-content link (`sr-only focus:not-sr-only`) as the first focusable element before the nav
- Keyboard and screen reader users can now Tab past the fixed nav directly to main content

### 2. Replace navigation buttons with anchor links
- Changed all `<button onClick={() => scrollToSection()}>` to `<a href="#section-id" onClick={handleNavClick}>` in `Navigation.tsx`
- Anchor links provide proper semantics: right-click → Copy Link, open in new tab, visible in status bar on hover
- Smooth scrolling is preserved via a click handler with `preventDefault()`
- External link (Blog) was already an `<a>` tag — unchanged
- DropdownMenu trigger remains as `<button>` (semantically correct for a disclosure widget)

### Files changed
- `src/pages/index.tsx` — skip-to-content link + `id="main-content"`
- `src/components/Navigation.tsx` — buttons → anchor links for all in-page nav items