### PR TITLE
fix: resolve biome lint and format errors

### DIFF
--- a/src/components/GoToTopButton.tsx
+++ b/src/components/GoToTopButton.tsx
@@ -1,32 +1,31 @@
-import { ChevronUp } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import type { FC, CSSProperties, KeyboardEvent } from "react";
+import { ChevronUp } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import type { CSSProperties, FC, KeyboardEvent } from 'react';
 
 interface GoToTopButtonProps {
   className?: string;
   showAfter?: number; // Show button after scrolling this many pixels
   smoothScroll?: boolean;
   showScrollProgress?: boolean; // Show scroll progress indicator
-  position?: "bottom-right" | "bottom-left" | "bottom-center"; // Button position
+  position?: 'bottom-right' | 'bottom-left' | 'bottom-center'; // Button position
 }
 
 const GoToTopButton: FC<GoToTopButtonProps> = ({
-  className = "",
+  className = '',
   showAfter = 150, // Show after scrolling just 150px
   smoothScroll = true,
   showScrollProgress = true,
-  position = "bottom-right",
+  position = 'bottom-right',
 }) => {
   const [isVisible, setIsVisible] = useState(false);
   const [scrollProgress, setScrollProgress] = useState(0);
 
   const updateScrollState = useCallback(() => {
     // Check if we're in a browser environment
-    if (typeof window === "undefined") return;
+    if (typeof window === 'undefined') return;
 
     const scrollTop = window.pageYOffset;
-    const docHeight =
-      document.documentElement.scrollHeight - window.innerHeight;
+    const docHeight = document.documentElement.scrollHeight - window.innerHeight;
     const scrollPercent = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
 
     // Show button after scrolling past threshold and keep it visible
@@ -52,14 +51,14 @@ const GoToTopButton: FC<GoToTopButtonProps> = ({
     };
 
     // Add scroll event listener
-    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener('scroll', handleScroll, { passive: true });
 
     // Initial check
     updateScrollState();
 
     // Cleanup
     return () => {
-      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener('scroll', handleScroll);
       if (animationFrameId !== null) {
         cancelAnimationFrame(animationFrameId);
       }
@@ -68,26 +67,26 @@ const GoToTopButton: FC<GoToTopButtonProps> = ({
 
   const scrollToTop = () => {
     // Check if we're in a browser environment
-    if (typeof window === "undefined") return;
+    if (typeof window === 'undefined') return;
 
     if (smoothScroll) {
       window.scrollTo({
         top: 0,
-        behavior: "smooth",
+        behavior: 'smooth',
       });
     } else {
       window.scrollTo(0, 0);
     }
 
     // Focus management for accessibility
-    const mainContent = document.querySelector("main");
+    const mainContent = document.querySelector('main');
     if (mainContent) {
       mainContent.focus();
     }
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key === "Enter" || event.key === " ") {
+    if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       scrollToTop();
     }
@@ -101,18 +100,18 @@ const GoToTopButton: FC<GoToTopButtonProps> = ({
   // Inline styles as fallback to ensure proper positioning
   const getInlineStyles = (): CSSProperties => {
     const baseStyles: CSSProperties = {
-      position: "fixed",
+      position: 'fixed',
       zIndex: 50,
-      bottom: "1.5rem",
+      bottom: '1.5rem',
     };
 
     switch (position) {
-      case "bottom-left":
-        return { ...baseStyles, left: "1.5rem" };
-      case "bottom-center":
-        return { ...baseStyles, left: "50%", transform: "translateX(-50%)" };
+      case 'bottom-left':
+        return { ...baseStyles, left: '1.5rem' };
+      case 'bottom-center':
+        return { ...baseStyles, left: '50%', transform: 'translateX(-50%)' };
       default:
-        return { ...baseStyles, right: "1.5rem" };
+        return { ...baseStyles, right: '1.5rem' };
     }
   };
 

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,25 +1,23 @@
-import { useTheme } from "next-themes";
-import { Toaster as Sonner } from "sonner";
-import type { ComponentProps } from "react";
+import { useTheme } from 'next-themes';
+import type { ComponentProps } from 'react';
+import { Toaster as Sonner } from 'sonner';
 
 type ToasterProps = ComponentProps<typeof Sonner>;
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
+  const { theme = 'system' } = useTheme();
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={theme as ToasterProps['theme']}
       className="toaster group"
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
-          description: "group-[.toast]:text-muted-foreground",
-          actionButton:
-            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
-          cancelButton:
-            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+          description: 'group-[.toast]:text-muted-foreground',
+          actionButton: 'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+          cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
         },
       }}
       {...props}

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -1,6 +1,6 @@
-import { useState, useEffect } from "react";
-import type { ReactNode } from "react";
-import type { ToastActionElement, ToastProps } from "@/components/ui/toast";
+import type { ToastActionElement, ToastProps } from '@/components/ui/toast';
+import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
 
 const TOAST_LIMIT = 1;
 const TOAST_REMOVE_DELAY = 1000000;
@@ -13,10 +13,10 @@ type ToasterToast = ToastProps & {
 };
 
 const actionTypes = {
-  ADD_TOAST: "ADD_TOAST",
-  UPDATE_TOAST: "UPDATE_TOAST",
-  DISMISS_TOAST: "DISMISS_TOAST",
-  REMOVE_TOAST: "REMOVE_TOAST",
+  ADD_TOAST: 'ADD_TOAST',
+  UPDATE_TOAST: 'UPDATE_TOAST',
+  DISMISS_TOAST: 'DISMISS_TOAST',
+  REMOVE_TOAST: 'REMOVE_TOAST',
 } as const;
 
 let count = 0;
@@ -30,20 +30,20 @@ type ActionType = typeof actionTypes;
 
 type Action =
   | {
-      type: ActionType["ADD_TOAST"];
+      type: ActionType['ADD_TOAST'];
       toast: ToasterToast;
     }
   | {
-      type: ActionType["UPDATE_TOAST"];
+      type: ActionType['UPDATE_TOAST'];
       toast: Partial<ToasterToast>;
     }
   | {
-      type: ActionType["DISMISS_TOAST"];
-      toastId?: ToasterToast["id"];
+      type: ActionType['DISMISS_TOAST'];
+      toastId?: ToasterToast['id'];
     }
   | {
-      type: ActionType["REMOVE_TOAST"];
-      toastId?: ToasterToast["id"];
+      type: ActionType['REMOVE_TOAST'];
+      toastId?: ToasterToast['id'];
     };
 
 interface State {
@@ -60,7 +60,7 @@ const addToRemoveQueue = (toastId: string) => {
   const timeout = setTimeout(() => {
     toastTimeouts.delete(toastId);
     dispatch({
-      type: "REMOVE_TOAST",
+      type: 'REMOVE_TOAST',
       toastId: toastId,
     });
   }, TOAST_REMOVE_DELAY);
@@ -70,21 +70,19 @@ const addToRemoveQueue = (toastId: string) => {
 
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {
-    case "ADD_TOAST":
+    case 'ADD_TOAST':
       return {
         ...state,
         toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
       };
 
-    case "UPDATE_TOAST":
+    case 'UPDATE_TOAST':
       return {
         ...state,
-        toasts: state.toasts.map((t) =>
-          t.id === action.toast.id ? { ...t, ...action.toast } : t,
-        ),
+        toasts: state.toasts.map((t) => (t.id === action.toast.id ? { ...t, ...action.toast } : t)),
       };
 
-    case "DISMISS_TOAST": {
+    case 'DISMISS_TOAST': {
       const { toastId } = action;
 
       // ! Side effects ! - This could be extracted into a dismissToast() action,
@@ -105,11 +103,11 @@ const reducer = (state: State, action: Action): State => {
                 ...t,
                 open: false,
               }
-            : t,
+            : t
         ),
       };
     }
-    case "REMOVE_TOAST":
+    case 'REMOVE_TOAST':
       if (action.toastId === undefined) {
         return {
           ...state,
@@ -134,20 +132,20 @@ function dispatch(action: Action) {
   }
 }
 
-type Toast = Omit<ToasterToast, "id">;
+type Toast = Omit<ToasterToast, 'id'>;
 
 function toast({ ...props }: Toast) {
   const id = genId();
 
   const update = (props: ToasterToast) =>
     dispatch({
-      type: "UPDATE_TOAST",
+      type: 'UPDATE_TOAST',
       toast: { ...props, id },
     });
-  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id });
+  const dismiss = () => dispatch({ type: 'DISMISS_TOAST', toastId: id });
 
   dispatch({
-    type: "ADD_TOAST",
+    type: 'ADD_TOAST',
     toast: {
       ...props,
       id,
@@ -181,7 +179,7 @@ function useToast() {
   return {
     ...state,
     toast,
-    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+    dismiss: (toastId?: string) => dispatch({ type: 'DISMISS_TOAST', toastId }),
   };
 }
 


### PR DESCRIPTION
## Summary
Fixes all 9 biome check errors reported by `pnpm run lint` / `biome check .`.

### Changes
- **Quote style**: Convert double quotes to single quotes per `biome.json` config (`quoteStyle: single`)
- **Import sorting**: Reorder imports to satisfy `organizeImports` rule
  - Sort named type imports alphabetically (`FC, CSSProperties` → `CSSProperties, FC`)
  - Move type imports before value imports where required
- **Formatting**: Fix line length and trailing comma issues in `use-toast.ts`

### Files changed
| File | Issues fixed |
|------|-------------|
| `src/components/GoToTopButton.tsx` | 3 errors (format + organizeImports + check) |
| `src/components/ui/sonner.tsx` | 3 errors (format + organizeImports + check) |
| `src/hooks/use-toast.ts` | 3 errors (format + organizeImports + check) |

### Verification
```bash
pnpm install
pnpm run lint    # → 0 errors
pnpm exec biome check .  # → 0 errors
```

No logic changes — formatting and import order only.